### PR TITLE
fix: allow method override in request body

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,20 @@ class Web {
         return cryptoRandomString({ length: 32 });
       },
 
+      methodOverride: [
+        req => {
+          const { _method } = req.body;
+          if (
+            typeof _method !== 'string' &&
+            !['PUT', 'DELETE'].includes(_method)
+          ) {
+            throw new Error(`method override of ${_method} is not valid`);
+          }
+
+          return _method;
+        }
+      ],
+
       helmet: {
         contentSecurityPolicy: defaultSrc
           ? {
@@ -298,15 +312,16 @@ class Web {
     // flash messages
     app.use(flash());
 
-    // method override
-    // (e.g. `<input type="hidden" name="_method" value="PUT" />`)
-    app.use(methodOverride());
-
     // body parser
     app.use(bodyParser());
 
     // pretty-printed json responses
     app.use(json());
+
+    // method override
+    // (e.g. `<input type="hidden" name="_method" value="PUT" />`)
+    if (this.config.methodOverride)
+      app.use(methodOverride(...this.config.methodOverride));
 
     // ajax request detection (sets `ctx.state.xhr` boolean)
     app.use(isajax());

--- a/test/test.js
+++ b/test/test.js
@@ -18,3 +18,27 @@ test('allows custom routes', async t => {
   t.is(res.status, 200);
   t.is(res.body.ok, 'ok');
 });
+
+test('default method override', async t => {
+  const router = new Router();
+
+  router.post('/', ctx => {
+    ctx.body = { method: 'post' };
+  });
+
+  router.put('/', ctx => {
+    ctx.body = { method: 'put' };
+  });
+
+  const web = new Web({
+    routes: router.routes()
+  });
+
+  const res = await request(web.server)
+    .post('/')
+    .send({ _method: 'PUT' })
+    .set('Accept', 'application/json');
+  t.is(res.status, 200);
+  t.is(res.body.method, 'put');
+  t.is(res.request.method, 'POST');
+});


### PR DESCRIPTION
Allow request body to honor `_method` property to override http method to `DELETE` and `PUT` where necessary.

relates to: https://github.com/ladjs/lad/issues/395